### PR TITLE
net/pfSense-pkg-mDNS-Bridge: Fix typo in Avahi input error.

### DIFF
--- a/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
+++ b/net/pfSense-pkg-mDNS-Bridge/files/usr/local/www/mdns-bridge.php
@@ -65,7 +65,7 @@ if ($_POST) {
 
 	// Check for Avahi conflict
 	if ($pconfig['enable'] && $avahi_enabled) {
-		$input_errors[] = gettext('Avahi relfection must be disabled before enabling mDNS Bridge');
+		$input_errors[] = gettext('Avahi reflection must be disabled before enabling mDNS Bridge');
 	}
 
 	// Validate interfaces


### PR DESCRIPTION
Fix a typo in the input error messages.  